### PR TITLE
Remove unused imports.

### DIFF
--- a/src/isa/exec.rs
+++ b/src/isa/exec.rs
@@ -1016,7 +1016,7 @@ impl InstructionSet for ReservedOp {
 mod tests {
     use super::*;
     use crate::data::{Layout, Step};
-    use crate::reg::{Reg16, Reg8, RegBlockAR};
+    use crate::reg::{Reg16};
 
     #[test]
     fn cmp_ne_test() {


### PR DESCRIPTION
This will fix Internet2-WG/rust-aluvm#58.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
