### PR TITLE
Pass `cargo test --all-features`.

### DIFF
--- a/src/isa/exec.rs
+++ b/src/isa/exec.rs
@@ -1018,6 +1018,9 @@ mod tests {
     use crate::data::{Layout, Step};
     use crate::reg::{Reg16};
 
+    #[cfg(feature = "secp256k1")]
+    use crate::reg::{Reg8, RegBlockAR};
+
     #[test]
     fn cmp_ne_test() {
         let mut register = CoreRegs::default();


### PR DESCRIPTION
Before applying this patch, I got errors.

* error[E0433]: failed to resolve: use of undeclared type `Reg8`
* error[E0433]: failed to resolve: use of undeclared type `RegBlockAR`

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
