### PR TITLE
Build `example/asm` only if it was specified `all` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,7 @@ all = ["std", "secp256k1", "curve25519", "strict_encoding", "serde"]
 std = ["amplify/std", "bitcoin_hashes/std", "secp256k1/std", "curve25519-dalek/std", "curve25519-dalek/alloc", "bech32/std"]
 curve25519 = ["curve25519-dalek"]
 serde = ["serde_crate", "serde_with", "amplify/serde", "bitcoin_hashes/serde", "std", "secp256k1/std", "curve25519-dalek/serde"]
+
+[[example]]
+name = "asm"
+required-features = ["all"]


### PR DESCRIPTION
This will fix #60 .

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
